### PR TITLE
redirectResponse - using full path (leaning on baseUrl) instead of relative

### DIFF
--- a/Router/ContentRouter.php
+++ b/Router/ContentRouter.php
@@ -11,16 +11,12 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
-
 use Opifer\ContentBundle\Model\ContentManagerInterface;
-use Opifer\ContentBundle\Model\ContentInterface;
-
 use Doctrine\ORM\NoResultException;
-
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
- * Content Router
+ * Content Router.
  */
 class ContentRouter implements RouterInterface
 {
@@ -40,7 +36,7 @@ class ContentRouter implements RouterInterface
     protected $request;
 
     /**
-     * The constructor for this service
+     * The constructor for this service.
      *
      * @param ContainerInterface $container
      */
@@ -54,25 +50,25 @@ class ContentRouter implements RouterInterface
     }
 
     /**
-     * Create the routes
+     * Create the routes.
      */
     private function createRoutes()
     {
         $this->routeCollection->add('_content', new Route('/{slug}', [
             '_controller' => 'OpiferContentBundle:Frontend/Content:view',
-            'slug'        => ''
+            'slug'        => '',
         ], [
-            'slug'        => "[a-zA-Z0-9\-_\/]*"
+            'slug'        => "[a-zA-Z0-9\-_\/]*",
         ], [
-            'expose'      => true
+            'expose'      => true,
         ]));
         $this->routeCollection->add('home', new Route('/', [
             '_controller' => 'OpiferContentBundle:Frontend/Content:view',
-            'slug'        => ''
+            'slug'        => '',
         ], [
-            'slug'        => "[a-zA-Z0-9\-_\/]*"
+            'slug'        => "[a-zA-Z0-9\-_\/]*",
         ], [
-            'expose'      => true
+            'expose'      => true,
         ]));
     }
 
@@ -102,27 +98,28 @@ class ContentRouter implements RouterInterface
                 $result['content'] = $this->contentManager->findActiveBySlug($result['slug']);
             } catch (NoResultException $e) {
                 try {
+
                     //is it directory index
                     if (substr($result['slug'], -1) == '/' || $result['slug'] == '') {
                         $result['content'] = $this->contentManager->findActiveBySlug($result['slug'].'index');
                     } else {
-                        if($this->contentManager->findActiveBySlug($result['slug'].'/index')) {
-                            $redirect = new RedirectResponse($result['slug'].'/');
+                        if ($this->contentManager->findActiveBySlug($result['slug'].'/index')) {
+                            $redirect = new RedirectResponse($this->request->getBaseUrl()."/".$result['slug'].'/');
                             $redirect->sendHeaders();
                             exit;
                         }
                     }
-                }catch (NoResultException $ex) {
+                } catch (NoResultException $ex) {
                     try {
                         $result['content'] = $this->contentManager->findActiveByAlias($result['slug']);
                     } catch (NoResultException $ex) {
-                        throw new ResourceNotFoundException('No page found for slug ' . $pathinfo);
+                        throw new ResourceNotFoundException('No page found for slug '.$pathinfo);
                     }
                 }
             }
         }
-        
-        if($result['content']->getSymlink()) {
+
+        if ($result['content']->getSymlink()) {
             $result['content'] = $this->contentManager->getRepository()->findOneById($result['content']->getSymlink());
         }
 
@@ -130,7 +127,7 @@ class ContentRouter implements RouterInterface
     }
 
     /**
-     * Generate an url for a supplied route
+     * Generate an url for a supplied route.
      *
      * @param string $name       The path
      * @param array  $parameters The route parameters
@@ -171,7 +168,7 @@ class ContentRouter implements RouterInterface
     }
 
     /**
-     * Getter for routeCollection
+     * Getter for routeCollection.
      *
      * @return \Symfony\Component\Routing\RouteCollection
      */

--- a/Tests/Router/ContentRouterTest.php
+++ b/Tests/Router/ContentRouterTest.php
@@ -28,7 +28,7 @@ class ContentRouterTest extends \PHPUnit_Framework_TestCase
     {
         $content = new Content();
 
-        $this->contentManager->shouldReceive('findActiveBySlug')->andReturn($content);
+        $this->contentManager->shouldReceive('findActiveBySlug', 'findActiveByAlias')->andReturn($content);
 
         $contentRouter = new ContentRouter($this->requestStack, $this->contentManager);
         $result = $contentRouter->match('/about');
@@ -41,7 +41,7 @@ class ContentRouterTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotMatch()
     {
-        $this->contentManager->shouldReceive('findActiveBySlug')->andThrow('Doctrine\ORM\NoResultException');
+        $this->contentManager->shouldReceive('findActiveBySlug', 'findActiveByAlias')->andThrow('Doctrine\ORM\NoResultException');
 
         $contentRouter = new ContentRouter($this->requestStack, $this->contentManager);
         $result = $contentRouter->match('/about');


### PR DESCRIPTION
Without using base url, in some cases wrong redirection would happen.

Example:

http://some_site/app_dev.php/dir1/dir2/ would work, but
http://some_site/app_dev.php/dir1/dir2 not (getting redirected to http://some_site/app_dev.php/dir1/dir1/dir2/)