### PR TITLE
Forward status code

### DIFF
--- a/Controller/Frontend/ContentController.php
+++ b/Controller/Frontend/ContentController.php
@@ -44,7 +44,8 @@ class ContentController extends Controller
         if ($layout->getAction()) {
             return $this->forward($layout->getAction(), [
                 'content' => $content,
-                'layout'  => $layout
+                'layout'  => $layout,
+                'statusCode' => $statusCode
             ]);
         }
 


### PR DESCRIPTION
Shouldn't the statuscode passed to the `ContentBundle:Content:view` be forwarded to the custom layout action? For example on 404 pages.